### PR TITLE
Updated dependencies to work with LTS 2.1

### DIFF
--- a/logger.cabal
+++ b/logger.cabal
@@ -76,12 +76,14 @@ library
   
   build-depends:
       base >=4.7 && <4.8,
-      transformers >=0.4 && <0.5,
-      time >=1.5 && <1.6,
+      transformers >=0.3.0.0 && <0.5,
+      transformers-compat >=0.4.0.0 && <0.5,
+      time >=1.4.2 && <1.6,
+      time-locale-compat ==0.1.0.1,
       ansi-wl-pprint >=0.6 && <0.7,
-      lens >=4.6 && <4.7,
+      lens >=4.6,
       template-haskell >=2.9 && <2.10,
-      mtl >=2.2 && <2.3,
+      mtl >=2.1.3.1 && <2.3,
       containers >=0.5 && <0.6,
       unagi-chan >=0.3 && <0.4
   

--- a/src/System/Log/Format.hs
+++ b/src/System/Log/Format.hs
@@ -18,7 +18,8 @@ module System.Log.Format where
 import System.Log.Log               (Log)
 import System.Log.Data              (Lvl(Lvl), Msg(Msg), Loc(Loc), Time(Time), LocData(LocData), LevelData(LevelData), readData, DataOf, Lookup)
 import Data.Time.Clock              (UTCTime)
-import Data.Time.Format             (formatTime, defaultTimeLocale)
+import Data.Time.Format             (formatTime)
+import Data.Time.Locale.Compat      (defaultTimeLocale)
 import Text.PrettyPrint.ANSI.Leijen
 
 


### PR DESCRIPTION
Hi

I have tweaked the cabal dependencies to work with the stackage long term support package collection.
see: https://www.stackage.org/lts

I am hoping to use your module to provide logging in a multi-threaded context. As yet, a bit untested. 

Will let you know how I get on.

Finlay
