### PR TITLE
cabal dependency file updated, less than dependencies removed.

### DIFF
--- a/logger.cabal
+++ b/logger.cabal
@@ -75,17 +75,17 @@ library
       OverloadedStrings
   
   build-depends:
-      base >=4.7 && <4.8,
-      transformers >=0.3.0.0 && <0.5,
-      transformers-compat >=0.4.0.0 && <0.5,
-      time >=1.4.2 && <1.6,
-      time-locale-compat ==0.1.0.1,
-      ansi-wl-pprint >=0.6 && <0.7,
-      lens >=4.6,
-      template-haskell >=2.9 && <2.10,
-      mtl >=2.1.3.1 && <2.3,
-      containers >=0.5 && <0.6,
-      unagi-chan >=0.3 && <0.4
+      base,
+      transformers,
+      transformers-compat,
+      time,
+      time-locale-compat,
+      ansi-wl-pprint,
+      lens,
+      template-haskell,
+      mtl,
+      containers,
+      unagi-chan
   
   hs-source-dirs:      src
   


### PR DESCRIPTION
I have removed all the less than constraints in the cabal file because they don't allow building the logger in the sandbox environment. 

Cabal build : Passing
Functionality change : None. 
