### PR TITLE
Fixed typographical error, changed appart to apart in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ As every logger transformer, `BaseLogger` has an appriopriate transformer type c
 main = print =<< runBaseLogger (Lvl, Msg, Time) test
 ```
 
-There is one very important design decision. All the logger transformers, appart from the base one, pass the newly registered log to underlying transformers. This way we can create a transformer that writes messages to disk and combine it with the one, that registers the logs in a list. There are some examples showing this behavior later in this document.
+There is one very important design decision. All the logger transformers, apart from the base one, pass the newly registered log to underlying transformers. This way we can create a transformer that writes messages to disk and combine it with the one, that registers the logs in a list. There are some examples showing this behavior later in this document.
 
 ### WriterLogger
 


### PR DESCRIPTION
@wdanilo, I've corrected a typographical error in the documentation of the [haskell-logger](https://github.com/wdanilo/haskell-logger) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
